### PR TITLE
Easy init methods to convert common time units to TimeInterval objects

### DIFF
--- a/Sources/Nanoseconds/Nanoseconds.swift
+++ b/Sources/Nanoseconds/Nanoseconds.swift
@@ -22,6 +22,12 @@ extension Nanoseconds: Comparable {
 }
 
 extension TimeInterval {
+    public init (nanoseconds: Double) { self = nanoseconds }
+    public init (microseconds: Double) { self = microseconds * 1000 }
+    public init (milliseconds: Double) { self = milliseconds * 1e+6 }
+    public init (seconds: Double) { self = seconds * 1e+9 }
+    public init (minutes: Double) { self = minutes * 6e+10 }
+    public init (hours: Double) { self = hours * 3.6e+12 }
     public var microsecond: Double { return self / 1000 } 
     public var milliseconds: Double { return self / 1e+6 }
     public var seconds: Double { return self / 1e+9 } 

--- a/Tests/NanosecondsTests/NanosecondsTests.swift
+++ b/Tests/NanosecondsTests/NanosecondsTests.swift
@@ -7,4 +7,19 @@ final class NanosecondsTests: XCTestCase {
         let end = Nanoseconds()
         XCTAssertGreaterThan(end, start)
     }
+
+    func testTimeIntervalInitMethods () {
+        let nanosecond: TimeInterval = TimeInterval(nanoseconds: 1)
+        XCTAssertEqual(nanosecond, 1)
+        let microsecond: TimeInterval = TimeInterval(microseconds: 1)
+        XCTAssertEqual(microsecond, 1000)
+        let milliseconds: TimeInterval = TimeInterval(milliseconds: 1)
+        XCTAssertEqual(milliseconds, 1e+6)
+        let seconds: TimeInterval = TimeInterval(seconds: 1)
+        XCTAssertEqual(seconds, 1e+9)
+        let minutes: TimeInterval = TimeInterval(minutes: 1)
+        XCTAssertEqual(minutes, 6e+10)
+        let hours: TimeInterval = TimeInterval(hours: 1)
+        XCTAssertEqual(hours, 3.6e+12)
+    }
 }


### PR DESCRIPTION
Created easy to use TimeInterval object inti methods to convert common time units to nanosecond, this includes: 

- nanoseconds: `TimeInterval(nanoseconds: 1)`
- microseconds `TimeInterval(microseconds: 1)`
- milliseconds: `TimeInterval(milliseconds: 1)`
- seconds: `TimeInterval(seconds: 1)`
- minutes: `TimeInterval(minutes: 1)`
- hours: `TimeInterval(hours: 1)`