### PR TITLE
Rename Nanoseconds to Now

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Remember to add **Nanoseconds** to your target as a dependency.
 ## Documentation
 
 #### Creating Timestamps
-Creating high resolution timestamps with nanosecond accuracy is easy, simply create a instant of `Nanoseconds` struct
+Creating high resolution timestamps with nanosecond accuracy is easy, simply create a instant of `Now` struct
 
 ```  swift
-let foo = Nanoseconds()
+let foo = Now()
 ```
 
 #### Creating Time Intervals
@@ -37,9 +37,9 @@ let foo = Nanoseconds()
 Use the built-in operators overloads to easily calculate and initialize [**TimeInterval**](https://developer.apple.com/documentation/foundation/timeinterval):
 
 ``` swift
-let start = Nanoseconds()
+let start = Now()
 sleep(1)
-let end = Nanoseconds()
+let end = Now()
 let duration = end - start
 print(duration)  //=> 1004222113.0
 ```

--- a/Sources/Nanoseconds/Nanoseconds.swift
+++ b/Sources/Nanoseconds/Nanoseconds.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Nanoseconds {
+public struct Now {
     var rawValue: Double
 
     public init() {
@@ -8,15 +8,15 @@ public struct Nanoseconds {
     }
 }
 
-extension Nanoseconds: Comparable {
-    public static func < (lhs: Nanoseconds, rhs: Nanoseconds) -> Bool {
+extension Now: Comparable {
+    public static func < (lhs: Now, rhs: Now) -> Bool {
         lhs.rawValue < rhs.rawValue
     }
-    public static func - (lhs: Nanoseconds, rhs: Nanoseconds) -> TimeInterval {
+    public static func - (lhs: Now, rhs: Now) -> TimeInterval {
         TimeInterval(lhs.rawValue - rhs.rawValue)
     }
 
-    public static func + (lhs: Nanoseconds, rhs: Nanoseconds) -> TimeInterval {
+    public static func + (lhs: Now, rhs: Now) -> TimeInterval {
         TimeInterval(lhs.rawValue + rhs.rawValue)
     }
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,2 +1,1 @@
-// LinuxMain.swift
 fatalError("Run the tests with `swift test --enable-test-discovery`")

--- a/Tests/NanosecondsTests/NanosecondsTests.swift
+++ b/Tests/NanosecondsTests/NanosecondsTests.swift
@@ -2,10 +2,22 @@ import XCTest
 @testable import Nanoseconds
 
 final class NanosecondsTests: XCTestCase {
-    func testResolution() {
-        let start = Nanoseconds()
-        let end = Nanoseconds()
+    func testNowResolution () {
+        let start = Now()
+        let end = Now()
         XCTAssertGreaterThan(end, start)
+    }
+
+    func testNowComparable () {
+        let start = Now()
+        let end = Now()
+        XCTAssertTrue((end - start) as Any is TimeInterval)
+        XCTAssertGreaterThan(end - start, 0)
+        XCTAssertTrue((start + end) as Any is TimeInterval)
+        XCTAssertTrue((start < end) as Any is Bool)
+        XCTAssertEqual(start < end, true)
+        XCTAssertTrue((start > end) as Any is Bool)
+        XCTAssertEqual(start > end, false)
     }
 
     func testTimeIntervalInitMethods () {


### PR DESCRIPTION
**Nanoseconds** has been renamed to **Now** to better describe its function of creating a timestamp.

``` swift
let timestamp = Now()
```