### PR TITLE
Use clock_gettime_nsec_np for current time

### DIFF
--- a/Sources/Nanoseconds/Now.swift
+++ b/Sources/Nanoseconds/Now.swift
@@ -13,7 +13,7 @@ public struct Now {
         Creates a new `Now` instance.
     */
     public init() {
-        self.rawValue = DispatchTime.now().rawValue
+        self.rawValue = clock_gettime_nsec_np(CLOCK_MONOTONIC)
     }
 }
 

--- a/Tests/NanosecondsTests/NowTests.swift
+++ b/Tests/NanosecondsTests/NowTests.swift
@@ -60,7 +60,7 @@ final class NowTests: XCTestCase {
         sleep(1)
         let end = Now()
         let difference = end - start
-        XCTAssertLessThan(difference, TimeInterval(nanoseconds: Double(end.rawValue)))
+        XCTAssertGreaterThanOrEqual(difference, 1)
     }
 
     func testAdd() {


### PR DESCRIPTION
Changed `DispatchTime.now().rawValue` to `clock_gettime_nsec_np(CLOCK_MONOTONIC)` to make it work correctly on Apple Silicon
Fixed subtraction test to make sense